### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[ablazleon/myexample](https://github.com/ablazleon/myexample.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[ablazleon/udagram-frontend](https://github.com/ablazleon/udagram-frontend.git) |  | []() | 
+[ablazleon/ml-api-docker-k8](https://github.com/ablazleon/ml-api-docker-k8.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[ablazleon/ml-api-docker-k8](https://github.com/ablazleon/ml-api-docker-k8.git) |  | []() | 
+[ablazleon/my-server](https://github.com/ablazleon/my-server.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[ablazleon/myexample](https://github.com/ablazleon/myexample.git) |  | []() | 
+[ablazleon/udagram-frontend](https://github.com/ablazleon/udagram-frontend.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[ablazleon/my-server](https://github.com/ablazleon/my-server.git) |  | []() | 
+[ablazleon/myserver](https://github.com/ablazleon/myserver.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: ablazleon
-  repo: my-server
-  url: https://github.com/ablazleon/my-server.git
+  repo: myserver
+  url: https://github.com/ablazleon/myserver.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: ablazleon
-  repo: ml-api-docker-k8
-  url: https://github.com/ablazleon/ml-api-docker-k8.git
+  repo: my-server
+  url: https://github.com/ablazleon/my-server.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: ablazleon
-  repo: myexample
-  url: https://github.com/ablazleon/myexample.git
+  repo: udagram-frontend
+  url: https://github.com/ablazleon/udagram-frontend.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: ablazleon
+  repo: myexample
+  url: https://github.com/ablazleon/myexample.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: ablazleon
-  repo: udagram-frontend
-  url: https://github.com/ablazleon/udagram-frontend.git
+  repo: ml-api-docker-k8
+  url: https://github.com/ablazleon/ml-api-docker-k8.git
   version: ""
   versionURL: ""

--- a/repositories/templates/ablazleon-ml-api-docker-k8-sr.yaml
+++ b/repositories/templates/ablazleon-ml-api-docker-k8-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: ml-api-docker-k8
+  name: ablazleon-ml-api-docker-k8
+spec:
+  description: Imported application for ablazleon/ml-api-docker-k8
+  httpCloneURL: https://github.com/ablazleon/ml-api-docker-k8.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: ml-api-docker-k8
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/ml-api-docker-k8.git

--- a/repositories/templates/ablazleon-my-server-sr.yaml
+++ b/repositories/templates/ablazleon-my-server-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: my-server
+  name: ablazleon-my-server
+spec:
+  description: Imported application for ablazleon/my-server
+  httpCloneURL: https://github.com/ablazleon/my-server.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: my-server
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/my-server.git

--- a/repositories/templates/ablazleon-myexample-sr.yaml
+++ b/repositories/templates/ablazleon-myexample-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: myexample
+  name: ablazleon-myexample
+spec:
+  description: Imported application for ablazleon/myexample
+  httpCloneURL: https://github.com/ablazleon/myexample.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: myexample
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/myexample.git

--- a/repositories/templates/ablazleon-myserver-sr.yaml
+++ b/repositories/templates/ablazleon-myserver-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: myserver
+  name: ablazleon-myserver
+spec:
+  description: Imported application for ablazleon/myserver
+  httpCloneURL: https://github.com/ablazleon/myserver.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: myserver
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/myserver.git

--- a/repositories/templates/ablazleon-udagram-frontend-sr.yaml
+++ b/repositories/templates/ablazleon-udagram-frontend-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ablazleon
+    provider: github
+    repository: udagram-frontend
+  name: ablazleon-udagram-frontend
+spec:
+  description: Imported application for ablazleon/udagram-frontend
+  httpCloneURL: https://github.com/ablazleon/udagram-frontend.git
+  org: ablazleon
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: udagram-frontend
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ablazleon/udagram-frontend.git


### PR DESCRIPTION
Update [ablazleon/myserver](https://github.com/ablazleon/myserver.git) 

Command run was `jx create quickstart --git-public=true`
<hr />

Update [ablazleon/my-server](https://github.com/ablazleon/my-server.git) 

Command run was `jx create quickstart --git-public=true`
<hr />

Update [ablazleon/ml-api-docker-k8](https://github.com/ablazleon/ml-api-docker-k8.git) 

Command run was `jx import --url https://github.com/ablazleon/ml-api-docker-k8.git`
<hr />

Update [ablazleon/udagram-frontend](https://github.com/ablazleon/udagram-frontend.git) 

Command run was `jx import --url https://github.com/ablazleon/udagram-frontend.git`
<hr />

Update [ablazleon/myexample](https://github.com/ablazleon/myexample.git) 

Command run was `jx create quickstart`